### PR TITLE
ci: add ci_post_clone.sh for Xcode Cloud JDK setup

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+echo "=== ci_post_clone.sh ==="
+
+# Xcode CloudにはJDKが入っていないため、Homebrewでインストール
+# Shared Framework (Kotlin) のビルドにGradle → JDKが必要
+echo "=== Installing JDK 17 ==="
+brew install --quiet openjdk@17
+export JAVA_HOME=$(brew --prefix openjdk@17)
+export PATH="$JAVA_HOME/bin:$PATH"
+java -version
+
+echo "=== ci_post_clone.sh done ==="


### PR DESCRIPTION
Xcode CloudにはJDKが搭載されていないため、ci_post_clone.shでJDK 17をHomebrewインストールする。 これによりGradleビルド（Shared Framework生成）がXcode Cloud上で実行可能になる。