### PR TITLE
fix(shared): parentNodeのSerialName不一致を修正

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/NodeDto.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/NodeDto.kt
@@ -15,7 +15,7 @@ data class NodeDto(
     val authorName: String = "",
     @SerialName("author_picture")
     val authorPicture: String? = null,
-    @SerialName("parent_node")
+    @SerialName("parentNode")
     val parentNode: ParentNodeDto? = null,
     val tags: List<TagDto> = emptyList(),
     val reactions: ReactionsDto = ReactionsDto(),


### PR DESCRIPTION
## Summary
- `NodeDto.parentNode` の `@SerialName` が `"parent_node"` (snake_case) だったが、APIは `"parentNode"` (camelCase) で返していた
- `ignoreUnknownKeys = true` により `parentNode` キーが無視され、常に `null` になっていた
- `@SerialName("parentNode")` に修正

## Root Cause
APIレスポンスの他フィールド (`author_id`, `created_at` 等) は snake_case だが、`parentNode` だけ camelCase で返されており、不統一だった。

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest` パス
- [x] 実機で派生ノード作成 → フィードで派生元が表示されることを確認

Closes WHITS-ISLAND/inspirehub#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)