### PR TITLE
Revert "fix(shared): parentNodeのSerialName不一致を修正"

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/NodeDto.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/NodeDto.kt
@@ -15,7 +15,7 @@ data class NodeDto(
     val authorName: String = "",
     @SerialName("author_picture")
     val authorPicture: String? = null,
-    @SerialName("parentNode")
+    @SerialName("parent_node")
     val parentNode: ParentNodeDto? = null,
     val tags: List<TagDto> = emptyList(),
     val reactions: ReactionsDto = ReactionsDto(),


### PR DESCRIPTION
Reverts WHITS-ISLAND/inspirehub-mobile#53

すでにサーバチームの修正がすすんでいるため、こちらの修正はrevert