### PR TITLE
fix(shared): UserDto逆シリアライズエラーを修正 (#56)

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/KtorAuthDataSource.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/KtorAuthDataSource.kt
@@ -3,6 +3,7 @@ package io.github.witsisland.inspirehub.data.source
 import co.touchlab.kermit.Logger
 import io.github.witsisland.inspirehub.data.dto.TokenResponseDto
 import io.github.witsisland.inspirehub.data.dto.UserDto
+import io.github.witsisland.inspirehub.data.dto.UserUpdateResponseDto
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
@@ -47,9 +48,10 @@ class KtorAuthDataSource(
     }
 
     override suspend fun updateUserName(name: String): UserDto {
-        return httpClient.patch("/users/me") {
+        val response: UserUpdateResponseDto = httpClient.patch("/users/me") {
             contentType(ContentType.Application.Json)
             setBody(mapOf("name" to name))
         }.body()
+        return response.user
     }
 }


### PR DESCRIPTION
## Summary
- `KtorAuthDataSource.updateUserName()` が `PATCH /users/me` のレスポンスを直接 `UserDto` としてデシリアライズしていたのを修正
- APIは `{ "user": { ... } }` というラッパー構造で返すため、`UserUpdateResponseDto` を経由するように変更
- 同様の処理を行う `KtorUserDataSource.updateProfile()` は既に正しく `UserUpdateResponseDto` を使用していた

## Root Cause
`KtorAuthDataSource.updateUserName()` で `.body<UserDto>()` としていたが、APIレスポンスは `{ "user": { "id": ..., "name": ..., "email": ... } }` 構造のため、トップレベルに `id`, `name`, `email` フィールドが見つからずデシリアライズエラーが発生していた。

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest` 通過
- [x] `./gradlew :composeApp:assembleDebug` 通過
- [ ] 実機でマイページから名前変更が成功することを確認

closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)