### PR TITLE
fix: 詳細画面の古いデータ表示とホーム画面のリロードを修正

### DIFF
--- a/iosApp/iosApp/HomeView.swift
+++ b/iosApp/iosApp/HomeView.swift
@@ -80,7 +80,7 @@ struct HomeView: View {
             }
         }
         .onAppear {
-            viewModel.loadNodes(forceRefresh: false)
+            viewModel.onAppear()
         }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/DetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/DetailViewModel.kt
@@ -67,6 +67,10 @@ class DetailViewModel(
      */
     fun loadDetail(nodeId: String) {
         viewModelScope.launch {
+            // 前のノード情報をクリアして古いデータの一瞬表示を防止 (#52)
+            nodeStore.selectNode(null)
+            _comments.value = emptyList()
+            _childNodes.value = emptyList()
             _isLoading.value = true
             _error.value = null
 

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/HomeViewModel.kt
@@ -14,6 +14,7 @@ import io.github.witsisland.inspirehub.domain.store.SortOrder
 import io.github.witsisland.inspirehub.domain.store.UserStore
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.datetime.Clock
 
 /**
  * ホーム画面ViewModel
@@ -58,6 +59,20 @@ class HomeViewModel(
     @NativeCoroutinesState
     val error: StateFlow<String?> = _error.asStateFlow()
 
+    /** 前回ノードをロードした時刻（epochMillis） */
+    private var lastLoadedAt: Long = 0L
+
+    /**
+     * 画面表示時に呼ぶ。
+     * 前回ロードから30秒以上経過していればリフレッシュ (#46)
+     */
+    fun onAppear() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        if (now - lastLoadedAt > STALE_THRESHOLD_MS) {
+            loadNodes(forceRefresh = true)
+        }
+    }
+
     fun loadNodes(forceRefresh: Boolean = false) {
         viewModelScope.launch {
             nodeStore.setLoading(true)
@@ -66,6 +81,7 @@ class HomeViewModel(
             val result = nodeRepository.getNodes()
             if (result.isSuccess) {
                 nodeStore.updateNodes(result.getOrThrow())
+                lastLoadedAt = Clock.System.now().toEpochMilliseconds()
             } else {
                 _error.value = result.exceptionOrNull()?.message ?: "Failed to load nodes"
             }
@@ -101,5 +117,10 @@ class HomeViewModel(
                 _error.value = result.exceptionOrNull()?.message ?: "Failed to toggle reaction"
             }
         }
+    }
+
+    companion object {
+        /** 30秒間はキャッシュを使い、超えたらリフレッシュ */
+        private const val STALE_THRESHOLD_MS = 30_000L
     }
 }


### PR DESCRIPTION
## Summary
- **#52 修正**: DetailViewModel.loadDetail()冒頭で前のノード情報(selectedNode, comments, childNodes)をnullリセットし、古い詳細データの一瞬表示を防止
- **#46 修正**: HomeViewModel.onAppear()を追加し、前回ロードから30秒以上経過していればリフレッシュ。HomeView.onAppearで呼び出し

## Test plan
- [x] shared層テスト (`./gradlew :shared:testDebugUnitTest`) パス
- [x] iOSビルド (`xcodebuild`) 成功
- [ ] 詳細画面で別のノードに遷移 → 前のノードが一瞬表示されないことを確認
- [ ] タブ切替でホーム画面に戻る → 30秒以上経過後にリフレッシュされることを確認
- [ ] pull-to-refreshは引き続き動作することを確認

## 動作確認用
```bash
open ~/.claude-worktrees/inspirehub-mobile/fix/phase1-2-stale-detail/iosApp/iosApp.xcodeproj
```

closes #52
closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)