### PR TITLE
chore(ios): テーマカラー統一とアイコン整理

### DIFF
--- a/iosApp/iosApp/DerivedPostView.swift
+++ b/iosApp/iosApp/DerivedPostView.swift
@@ -68,7 +68,7 @@ struct DerivedPostView: View {
                             }
                         Button(action: addTag) {
                             Image(systemName: "plus.circle.fill")
-                                .foregroundColor(.blue)
+                                .foregroundColor(.appPrimary)
                         }
                         .disabled(tagInput.trimmingCharacters(in: .whitespaces).isEmpty)
                     }

--- a/iosApp/iosApp/DetailView.swift
+++ b/iosApp/iosApp/DetailView.swift
@@ -21,7 +21,7 @@ struct DetailView: View {
                 VStack(spacing: 16) {
                     Image(systemName: "exclamationmark.triangle")
                         .font(.system(size: 40))
-                        .foregroundColor(.orange)
+                        .foregroundColor(.appSecondary)
                     Text(error)
                         .font(.subheadline)
                         .foregroundColor(.secondary)
@@ -107,8 +107,8 @@ struct DetailView: View {
                         .font(.caption)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
-                        .background(Color.blue.opacity(0.1))
-                        .foregroundColor(.blue)
+                        .background(Color.appPrimary.opacity(0.1))
+                        .foregroundColor(.appPrimary)
                         .cornerRadius(8)
                 }
             }
@@ -260,7 +260,7 @@ struct DetailView: View {
             .foregroundColor(.white)
             .frame(maxWidth: .infinity)
             .padding(12)
-            .background(Color.orange)
+            .background(Color.appSecondary)
             .cornerRadius(10)
         }
         .sheet(isPresented: $showDerivedPost) {
@@ -280,7 +280,7 @@ struct DetailView: View {
                     NavigationLink(destination: DetailView(nodeId: child.id)) {
                         HStack(spacing: 8) {
                             Image(systemName: "arrow.turn.down.right")
-                                .foregroundColor(.blue)
+                                .foregroundColor(.appPrimary)
                                 .font(.caption)
                             Text(child.title)
                                 .font(.subheadline)
@@ -323,7 +323,7 @@ struct DetailView: View {
                         viewModel.submitComment()
                     }) {
                         Image(systemName: "paperplane.fill")
-                            .foregroundColor(.blue)
+                            .foregroundColor(.appPrimary)
                             .frame(width: 44, height: 44)
                             .contentShape(Rectangle())
                     }
@@ -341,10 +341,10 @@ struct DetailView: View {
                         Text("ログインしてコメントする")
                             .font(.subheadline)
                     }
-                    .foregroundColor(.blue)
+                    .foregroundColor(.appPrimary)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 10)
-                    .background(Color.blue.opacity(0.05))
+                    .background(Color.appPrimary.opacity(0.05))
                     .cornerRadius(8)
                 }
             }

--- a/iosApp/iosApp/DiscoverView.swift
+++ b/iosApp/iosApp/DiscoverView.swift
@@ -110,8 +110,8 @@ struct DiscoverView: View {
                                 }
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 8)
-                                .background(Color.blue.opacity(0.1))
-                                .foregroundColor(.blue)
+                                .background(Color.appPrimary.opacity(0.1))
+                                .foregroundColor(.appPrimary)
                                 .cornerRadius(16)
                             }
                             .buttonStyle(.plain)

--- a/iosApp/iosApp/HomeView.swift
+++ b/iosApp/iosApp/HomeView.swift
@@ -100,7 +100,7 @@ struct HomeView: View {
                                 .foregroundColor(isCurrentTab(tab) ? .primary : .secondary)
 
                             Rectangle()
-                                .fill(isCurrentTab(tab) ? Color.blue : Color.clear)
+                                .fill(isCurrentTab(tab) ? Color.appPrimary : Color.clear)
                                 .frame(height: 2)
                         }
                         .frame(minHeight: 44)
@@ -298,8 +298,8 @@ struct NodeCardView: View {
                         .font(.caption)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
-                        .background(Color.blue.opacity(0.1))
-                        .foregroundColor(.blue)
+                        .background(Color.appPrimary.opacity(0.1))
+                        .foregroundColor(.appPrimary)
                         .cornerRadius(8)
                 }
             }

--- a/iosApp/iosApp/IdeaPostView.swift
+++ b/iosApp/iosApp/IdeaPostView.swift
@@ -50,7 +50,7 @@ struct IdeaPostView: View {
                             }
                         Button(action: addTag) {
                             Image(systemName: "plus.circle.fill")
-                                .foregroundColor(.blue)
+                                .foregroundColor(.appPrimary)
                         }
                         .disabled(tagInput.trimmingCharacters(in: .whitespaces).isEmpty)
                     }

--- a/iosApp/iosApp/IssuePostView.swift
+++ b/iosApp/iosApp/IssuePostView.swift
@@ -52,7 +52,7 @@ struct IssuePostView: View {
                             }
                         Button(action: addTag) {
                             Image(systemName: "plus.circle.fill")
-                                .foregroundColor(.blue)
+                                .foregroundColor(.appPrimary)
                         }
                         .disabled(tagInput.trimmingCharacters(in: .whitespaces).isEmpty)
                     }
@@ -128,8 +128,8 @@ struct RemovableTagChip: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 5)
-        .background(Color.blue.opacity(0.1))
-        .foregroundColor(.blue)
+        .background(Color.appPrimary.opacity(0.1))
+        .foregroundColor(.appPrimary)
         .cornerRadius(8)
     }
 }
@@ -141,8 +141,8 @@ struct TagChip: View {
             .font(.caption)
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
-            .background(Color.blue.opacity(0.1))
-            .foregroundColor(.blue)
+            .background(Color.appPrimary.opacity(0.1))
+            .foregroundColor(.appPrimary)
             .cornerRadius(8)
     }
 }

--- a/iosApp/iosApp/LoginView.swift
+++ b/iosApp/iosApp/LoginView.swift
@@ -16,7 +16,7 @@ struct LoginView: View {
             VStack(spacing: 16) {
                 Image(systemName: "lightbulb.fill")
                     .font(.system(size: 80))
-                    .foregroundColor(.orange)
+                    .foregroundColor(.appSecondary)
 
                 Text("InspireHub")
                     .font(.largeTitle)
@@ -39,7 +39,7 @@ struct LoginView: View {
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(Color.blue)
+                .background(Color.appPrimary)
                 .cornerRadius(12)
             }
             .disabled(viewModel.isLoading)

--- a/iosApp/iosApp/MainTabView.swift
+++ b/iosApp/iosApp/MainTabView.swift
@@ -70,7 +70,7 @@ struct MainTabView: View {
                     .fontWeight(.bold)
                     .foregroundColor(.white)
                     .frame(width: 56, height: 56)
-                    .background(Color.blue)
+                    .background(Color.appPrimary)
                     .clipShape(Circle())
                     .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
             }
@@ -139,7 +139,7 @@ struct MainTabView: View {
                     .foregroundColor(.white)
                     .frame(maxWidth: 200)
                     .padding(.vertical, 12)
-                    .background(Color.blue)
+                    .background(Color.appPrimary)
                     .cornerRadius(12)
             }
         }

--- a/iosApp/iosApp/MapView.swift
+++ b/iosApp/iosApp/MapView.swift
@@ -17,7 +17,7 @@ struct MapView: View {
                 VStack(spacing: 16) {
                     Image(systemName: "exclamationmark.triangle")
                         .font(.system(size: 40))
-                        .foregroundColor(.orange)
+                        .foregroundColor(.appSecondary)
                     Text(error)
                         .font(.subheadline)
                         .foregroundColor(.secondary)

--- a/iosApp/iosApp/MyPageView.swift
+++ b/iosApp/iosApp/MyPageView.swift
@@ -41,7 +41,7 @@ struct MyPageView: View {
         VStack(spacing: 12) {
             Image(systemName: "person.circle.fill")
                 .font(.system(size: 72))
-                .foregroundColor(.blue)
+                .foregroundColor(.appPrimary)
 
             if let user = viewModel.currentUser as? User {
                 if viewModel.isEditingName as? Bool == true {
@@ -55,7 +55,7 @@ struct MyPageView: View {
                         .font(.caption)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 4)
-                        .background(Color.blue.opacity(0.1))
+                        .background(Color.appPrimary.opacity(0.1))
                         .cornerRadius(8)
                 }
             } else {
@@ -83,7 +83,7 @@ struct MyPageView: View {
                 viewModel.startEditingName()
             }) {
                 Image(systemName: "pencil.circle")
-                    .foregroundColor(.blue)
+                    .foregroundColor(.appPrimary)
                     .font(.title3)
             }
         }

--- a/iosApp/iosApp/NodeTypeStyle.swift
+++ b/iosApp/iosApp/NodeTypeStyle.swift
@@ -10,14 +10,14 @@ enum NodeTypeStyle {
 
     /// The foreground/accent color for a given node type.
     ///
-    /// - Issue: Red -- conveys urgency and problem-awareness
-    /// - Idea: Blue -- aligns with the app's Primary color, conveys creativity
-    /// - Project: Green -- conveys progress and growth
+    /// - Issue: Coral-red -- conveys urgency and problem-awareness
+    /// - Idea: Indigo-blue -- aligns with the app's Primary color, conveys creativity
+    /// - Project: Teal-green -- conveys progress and growth
     static func color(for type: NodeType) -> Color {
         switch type {
-        case .issue: return .red
-        case .idea: return .blue
-        case .project: return .green
+        case .issue: return .issueColor
+        case .idea: return .ideaColor
+        case .project: return .projectColor
         default: return .secondary
         }
     }
@@ -32,7 +32,7 @@ enum NodeTypeStyle {
     /// The SF Symbol name for a given node type.
     static func icon(for type: NodeType) -> String {
         switch type {
-        case .issue: return "exclamationmark.triangle.fill"
+        case .issue: return "exclamationmark.circle.fill"
         case .idea: return "lightbulb.fill"
         case .project: return "folder.fill"
         default: return "doc.fill"

--- a/iosApp/iosApp/Theme/AppColors.swift
+++ b/iosApp/iosApp/Theme/AppColors.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Centralized color definitions for InspireHub.
+/// All screens must reference these instead of hard-coding Color literals.
+extension Color {
+    // MARK: - Brand
+
+    /// Primary brand color (blue-indigo) used for key actions and active indicators.
+    static let appPrimary = Color(red: 0.25, green: 0.42, blue: 0.88)
+
+    /// Secondary accent color (warm orange) used for creative / derive actions.
+    static let appSecondary = Color(red: 0.95, green: 0.55, blue: 0.25)
+
+    // MARK: - Node Types
+
+    /// Issue nodes: warm coral-red conveying urgency.
+    static let issueColor = Color(red: 0.90, green: 0.30, blue: 0.25)
+
+    /// Idea nodes: indigo-blue conveying creativity.
+    static let ideaColor = Color(red: 0.25, green: 0.42, blue: 0.88)
+
+    /// Project nodes: teal-green conveying growth and progress.
+    static let projectColor = Color(red: 0.18, green: 0.72, blue: 0.55)
+}


### PR DESCRIPTION
## Summary

- `AppColors.swift` を新規作成し、アプリ全体のカラーパレットを一元管理（`appPrimary`, `appSecondary`, `issueColor`, `ideaColor`, `projectColor`）
- `NodeTypeStyle` の色定義を AppColors 経由に統一し、課題アイコンを `exclamationmark.circle.fill` に変更
- 全画面のハードコード色（`.blue`, `.orange`）をテーマカラーに置換。エラー/ログアウトの `.red` はセマンティックカラーとして維持

Closes #38, Closes #48

## Test plan

- [ ] iOSビルドが成功すること (**確認済み**)
- [ ] ホーム画面: タブバーのアクティブインジケーターがappPrimaryカラーであること
- [ ] ホーム画面: タグチップ・リアクション済み表示がappPrimaryカラーであること
- [ ] 詳細画面: 派生ボタンがappSecondaryカラーであること
- [ ] 詳細画面: コメント送信アイコン・ログインリンクがappPrimaryカラーであること
- [ ] ディスカバー画面: タグバッジがappPrimaryカラーであること
- [ ] マップ画面: エラーアイコンがappSecondaryカラーであること
- [ ] ログイン画面: ロゴがappSecondary、ボタンがappPrimaryであること
- [ ] マイページ: プロフィールアイコン・編集ボタンがappPrimaryであること
- [ ] 投稿画面: タグ追加ボタン・タグチップがappPrimaryであること
- [ ] NodeTypeStyle: 課題アイコンが `exclamationmark.circle.fill` であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)