### PR TITLE
fix(shared): limit/offsetクエリパラメータの透過を修正 (#36)

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/CommentRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/CommentRepositoryImpl.kt
@@ -13,9 +13,13 @@ class CommentRepositoryImpl(
     private val dataSource: CommentDataSource
 ) : CommentRepository {
 
-    override suspend fun getComments(nodeId: String): Result<List<Comment>> {
+    override suspend fun getComments(
+        nodeId: String,
+        limit: Int,
+        offset: Int
+    ): Result<List<Comment>> {
         return try {
-            val dtos = dataSource.getComments(nodeId)
+            val dtos = dataSource.getComments(nodeId, limit = limit, offset = offset)
             Result.success(dtos.map { it.toDomain() })
         } catch (e: Exception) {
             Result.failure(e)

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/NodeRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/NodeRepositoryImpl.kt
@@ -76,7 +76,7 @@ class NodeRepositoryImpl(
 
     override suspend fun getChildNodes(parentNodeId: String): Result<List<Node>> {
         return try {
-            val dtos = nodeDataSource.getNodes()
+            val dtos = nodeDataSource.getNodes(limit = 100)
             val children = dtos
                 .map { it.toDomain() }
                 .filter { it.parentNode?.id == parentNodeId }

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/repository/CommentRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/repository/CommentRepository.kt
@@ -10,8 +10,14 @@ interface CommentRepository {
     /**
      * ノードのコメント一覧を取得
      * @param nodeId ノードID
+     * @param limit 取得件数（最大100）
+     * @param offset オフセット
      */
-    suspend fun getComments(nodeId: String): Result<List<Comment>>
+    suspend fun getComments(
+        nodeId: String,
+        limit: Int = 20,
+        offset: Int = 0
+    ): Result<List<Comment>>
 
     /**
      * コメントを作成

--- a/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/domain/repository/FakeCommentRepository.kt
+++ b/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/domain/repository/FakeCommentRepository.kt
@@ -31,7 +31,11 @@ class FakeCommentRepository : CommentRepository {
     var lastCreateCommentParentId: String? = null
     var lastDeleteCommentId: String? = null
 
-    override suspend fun getComments(nodeId: String): Result<List<Comment>> {
+    override suspend fun getComments(
+        nodeId: String,
+        limit: Int,
+        offset: Int
+    ): Result<List<Comment>> {
         getCommentsCallCount++
         lastGetCommentsNodeId = nodeId
 


### PR DESCRIPTION
## Summary
- `CommentRepository.getComments()` に `limit/offset` パラメータを追加し、DataSourceまで正しく透過するように修正
- `NodeRepositoryImpl.getChildNodes()` で `limit=100` を明示指定（デフォルト20の取りこぼし防止）

## Background
バックエンド（inspirehub#30）修正完了に伴い、mobile側でもlimit/offset送信を完全復活させる。
KtorDataSource層は既に送信実装済みだったが、CommentRepository層でパラメータが落ちていた。

## Changes
- `CommentRepository` インターフェース: `getComments()` に `limit: Int = 20, offset: Int = 0` 追加
- `CommentRepositoryImpl`: DataSourceに `limit/offset` を渡すよう修正
- `NodeRepositoryImpl.getChildNodes()`: `getNodes(limit = 100)` で取りこぼし防止
- `FakeCommentRepository`: 新シグネチャに追従

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest` 全パス
- [ ] `./gradlew :composeApp:assembleDebug` Androidビルド確認
- [ ] バックエンドに対してlimit/offsetが正しく送信されることをネットワークログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)