### PR TITLE
feat(shared): 投稿の編集・削除機能を追加 (#40)

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/NodeRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/NodeRepositoryImpl.kt
@@ -62,6 +62,36 @@ class NodeRepositoryImpl(
         }
     }
 
+    override suspend fun updateNode(
+        id: String,
+        title: String,
+        content: String,
+        tags: List<String>
+    ): Result<Node> {
+        return try {
+            nodeDataSource.updateNode(
+                id = id,
+                title = title,
+                content = content,
+                tags = tags
+            )
+            // PUT /nodes/{id} は { "message": string } のみ返す → getNode で再取得
+            val dto = nodeDataSource.getNode(id)
+            Result.success(dto.toDomain())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteNode(id: String): Result<Unit> {
+        return try {
+            nodeDataSource.deleteNode(id)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     override suspend fun toggleLike(nodeId: String): Result<Node> {
         return try {
             // POST /nodes/{id}/like は ReactionSummaryDto を返す

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/KtorNodeDataSource.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/KtorNodeDataSource.kt
@@ -82,22 +82,22 @@ class KtorNodeDataSource(
     /**
      * PUT /nodes/{id}
      * Request: UpdateNodeRequestDto
-     * Response: NodeDto
+     * Response: { "message": string }
      */
     override suspend fun updateNode(
         id: String,
         title: String,
         content: String,
         tags: List<String>
-    ): NodeDto {
-        return httpClient.put("/nodes/$id") {
+    ) {
+        httpClient.put("/nodes/$id") {
             contentType(ContentType.Application.Json)
             setBody(UpdateNodeRequestDto(
                 title = title,
                 content = content,
                 tags = tags
             ))
-        }.body()
+        }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/MockNodeDataSource.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/MockNodeDataSource.kt
@@ -68,7 +68,7 @@ class MockNodeDataSource : NodeDataSource {
         title: String,
         content: String,
         tags: List<String>
-    ): NodeDto {
+    ) {
         val index = nodes.indexOfFirst { it.id == id }
         if (index == -1) throw NoSuchElementException("Node not found: $id")
         val updated = nodes[index].copy(
@@ -77,7 +77,6 @@ class MockNodeDataSource : NodeDataSource {
             updatedAt = "2026-02-01T12:00:00Z"
         )
         nodes[index] = updated
-        return updated
     }
 
     override suspend fun deleteNode(id: String) {

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/NodeDataSource.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/NodeDataSource.kt
@@ -53,7 +53,7 @@ interface NodeDataSource {
     /**
      * PUT /nodes/{id}
      * Request: UpdateNodeRequestDto
-     * Response: NodeDto
+     * Response: { "message": string }
      *
      * @param id ノードID
      * @param title タイトル
@@ -65,7 +65,7 @@ interface NodeDataSource {
         title: String,
         content: String,
         tags: List<String> = emptyList()
-    ): NodeDto
+    )
 
     /**
      * DELETE /nodes/{id}

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/repository/NodeRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/repository/NodeRepository.kt
@@ -23,6 +23,15 @@ interface NodeRepository {
         tags: List<String> = emptyList()
     ): Result<Node>
 
+    suspend fun updateNode(
+        id: String,
+        title: String,
+        content: String,
+        tags: List<String> = emptyList()
+    ): Result<Node>
+
+    suspend fun deleteNode(id: String): Result<Unit>
+
     suspend fun toggleLike(nodeId: String): Result<Node>
 
     suspend fun getChildNodes(parentNodeId: String): Result<List<Node>>

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/store/NodeStore.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/store/NodeStore.kt
@@ -38,6 +38,20 @@ class NodeStore {
         _nodes.value = listOf(node) + _nodes.value
     }
 
+    fun updateNode(updated: Node) {
+        _nodes.value = _nodes.value.map { if (it.id == updated.id) updated else it }
+        if (_selectedNode.value?.id == updated.id) {
+            _selectedNode.value = updated
+        }
+    }
+
+    fun removeNode(nodeId: String) {
+        _nodes.value = _nodes.value.filter { it.id != nodeId }
+        if (_selectedNode.value?.id == nodeId) {
+            _selectedNode.value = null
+        }
+    }
+
     fun selectNode(node: Node?) {
         _selectedNode.value = node
     }

--- a/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/domain/repository/FakeNodeRepository.kt
+++ b/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/domain/repository/FakeNodeRepository.kt
@@ -10,6 +10,8 @@ class FakeNodeRepository : NodeRepository {
     var getNodesResult: Result<List<Node>>? = null
     var getNodeResult: Result<Node>? = null
     var createNodeResult: Result<Node>? = null
+    var updateNodeResult: Result<Node>? = null
+    var deleteNodeResult: Result<Unit>? = null
     var toggleLikeResult: Result<Node>? = null
     var getChildNodesResult: Result<List<Node>>? = null
     var searchNodesResult: Result<List<Node>>? = null
@@ -21,6 +23,8 @@ class FakeNodeRepository : NodeRepository {
     var getNodesCallCount = 0
     var getNodeCallCount = 0
     var createNodeCallCount = 0
+    var updateNodeCallCount = 0
+    var deleteNodeCallCount = 0
     var toggleLikeCallCount = 0
     var getChildNodesCallCount = 0
     var searchNodesCallCount = 0
@@ -35,6 +39,11 @@ class FakeNodeRepository : NodeRepository {
     var lastCreateNodeType: NodeType? = null
     var lastCreateNodeParentNodeId: String? = null
     var lastCreateNodeTags: List<String>? = null
+    var lastUpdateNodeId: String? = null
+    var lastUpdateNodeTitle: String? = null
+    var lastUpdateNodeContent: String? = null
+    var lastUpdateNodeTags: List<String>? = null
+    var lastDeleteNodeId: String? = null
     var lastToggleLikeNodeId: String? = null
     var lastGetChildNodesParentNodeId: String? = null
     var lastSearchQuery: String? = null
@@ -80,6 +89,30 @@ class FakeNodeRepository : NodeRepository {
 
         if (shouldReturnError) return Result.failure(Exception(errorMessage))
         return createNodeResult ?: error("createNodeResult not set")
+    }
+
+    override suspend fun updateNode(
+        id: String,
+        title: String,
+        content: String,
+        tags: List<String>
+    ): Result<Node> {
+        updateNodeCallCount++
+        lastUpdateNodeId = id
+        lastUpdateNodeTitle = title
+        lastUpdateNodeContent = content
+        lastUpdateNodeTags = tags
+
+        if (shouldReturnError) return Result.failure(Exception(errorMessage))
+        return updateNodeResult ?: error("updateNodeResult not set")
+    }
+
+    override suspend fun deleteNode(id: String): Result<Unit> {
+        deleteNodeCallCount++
+        lastDeleteNodeId = id
+
+        if (shouldReturnError) return Result.failure(Exception(errorMessage))
+        return deleteNodeResult ?: Result.success(Unit)
     }
 
     override suspend fun toggleLike(nodeId: String): Result<Node> {
@@ -134,6 +167,8 @@ class FakeNodeRepository : NodeRepository {
         getNodesResult = null
         getNodeResult = null
         createNodeResult = null
+        updateNodeResult = null
+        deleteNodeResult = null
         toggleLikeResult = null
         getChildNodesResult = null
         searchNodesResult = null
@@ -143,6 +178,8 @@ class FakeNodeRepository : NodeRepository {
         getNodesCallCount = 0
         getNodeCallCount = 0
         createNodeCallCount = 0
+        updateNodeCallCount = 0
+        deleteNodeCallCount = 0
         toggleLikeCallCount = 0
         getChildNodesCallCount = 0
         searchNodesCallCount = 0
@@ -156,6 +193,11 @@ class FakeNodeRepository : NodeRepository {
         lastCreateNodeType = null
         lastCreateNodeParentNodeId = null
         lastCreateNodeTags = null
+        lastUpdateNodeId = null
+        lastUpdateNodeTitle = null
+        lastUpdateNodeContent = null
+        lastUpdateNodeTags = null
+        lastDeleteNodeId = null
         lastToggleLikeNodeId = null
         lastGetChildNodesParentNodeId = null
         lastSearchQuery = null

--- a/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/DetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/DetailViewModelTest.kt
@@ -268,5 +268,144 @@ class DetailViewModelTest : MainDispatcherRule() {
         assertNull(viewModel.error.value)
         assertEquals("", viewModel.commentText.value)
         assertFalse(viewModel.isCommentSubmitting.value)
+        assertFalse(viewModel.isEditing.value)
+        assertFalse(viewModel.isDeleted.value)
+    }
+
+    // --- 編集機能のテスト ---
+
+    @Test
+    fun `startEditing - 編集モードが開始されタイトルと内容がセットされること`() = runTest {
+        nodeStore.selectNode(sampleNode)
+
+        viewModel.startEditing()
+
+        assertTrue(viewModel.isEditing.value)
+        assertEquals(sampleNode.title, viewModel.editTitle.value)
+        assertEquals(sampleNode.content, viewModel.editContent.value)
+    }
+
+    @Test
+    fun `startEditing - 選択ノードがない場合は編集モードにならないこと`() = runTest {
+        viewModel.startEditing()
+
+        assertFalse(viewModel.isEditing.value)
+    }
+
+    @Test
+    fun `cancelEditing - 編集モードがキャンセルされること`() = runTest {
+        nodeStore.selectNode(sampleNode)
+        viewModel.startEditing()
+
+        viewModel.cancelEditing()
+
+        assertFalse(viewModel.isEditing.value)
+        assertEquals("", viewModel.editTitle.value)
+        assertEquals("", viewModel.editContent.value)
+    }
+
+    @Test
+    fun `updateEditTitle - 編集タイトルが更新されること`() = runTest {
+        viewModel.updateEditTitle("新しいタイトル")
+
+        assertEquals("新しいタイトル", viewModel.editTitle.value)
+    }
+
+    @Test
+    fun `updateEditContent - 編集内容が更新されること`() = runTest {
+        viewModel.updateEditContent("新しい内容")
+
+        assertEquals("新しい内容", viewModel.editContent.value)
+    }
+
+    @Test
+    fun `saveEdit - 編集保存が成功すること`() = runTest {
+        nodeStore.selectNode(sampleNode)
+        viewModel.startEditing()
+        viewModel.updateEditTitle("更新後のタイトル")
+        viewModel.updateEditContent("更新後の内容")
+
+        val updatedNode = sampleNode.copy(
+            title = "更新後のタイトル",
+            content = "更新後の内容"
+        )
+        fakeNodeRepository.updateNodeResult = Result.success(updatedNode)
+
+        viewModel.saveEdit()
+
+        assertEquals(1, fakeNodeRepository.updateNodeCallCount)
+        assertEquals("node1", fakeNodeRepository.lastUpdateNodeId)
+        assertEquals("更新後のタイトル", fakeNodeRepository.lastUpdateNodeTitle)
+        assertEquals("更新後の内容", fakeNodeRepository.lastUpdateNodeContent)
+        assertFalse(viewModel.isEditing.value)
+        assertFalse(viewModel.isLoading.value)
+        assertNull(viewModel.error.value)
+        viewModel.selectedNode.test {
+            assertEquals(updatedNode, awaitItem())
+        }
+    }
+
+    @Test
+    fun `saveEdit - タイトルが空の場合は保存しないこと`() = runTest {
+        nodeStore.selectNode(sampleNode)
+        viewModel.startEditing()
+        viewModel.updateEditTitle("   ")
+
+        viewModel.saveEdit()
+
+        assertEquals(0, fakeNodeRepository.updateNodeCallCount)
+    }
+
+    @Test
+    fun `saveEdit - 失敗時にエラーが設定されること`() = runTest {
+        nodeStore.selectNode(sampleNode)
+        viewModel.startEditing()
+        viewModel.updateEditTitle("更新タイトル")
+        viewModel.updateEditContent("更新内容")
+
+        val errorMessage = "Update failed"
+        fakeNodeRepository.updateNodeResult = Result.failure(Exception(errorMessage))
+
+        viewModel.saveEdit()
+
+        assertEquals(errorMessage, viewModel.error.value)
+        assertTrue(viewModel.isEditing.value) // 編集モードは維持
+        assertFalse(viewModel.isLoading.value)
+    }
+
+    // --- 削除機能のテスト ---
+
+    @Test
+    fun `deleteNode - 削除が成功すること`() = runTest {
+        nodeStore.selectNode(sampleNode)
+        fakeNodeRepository.deleteNodeResult = Result.success(Unit)
+
+        viewModel.deleteNode()
+
+        assertEquals(1, fakeNodeRepository.deleteNodeCallCount)
+        assertEquals("node1", fakeNodeRepository.lastDeleteNodeId)
+        assertTrue(viewModel.isDeleted.value)
+        assertFalse(viewModel.isLoading.value)
+        assertNull(viewModel.error.value)
+    }
+
+    @Test
+    fun `deleteNode - 選択ノードがない場合は何もしないこと`() = runTest {
+        viewModel.deleteNode()
+
+        assertEquals(0, fakeNodeRepository.deleteNodeCallCount)
+    }
+
+    @Test
+    fun `deleteNode - 失敗時にエラーが設定されること`() = runTest {
+        nodeStore.selectNode(sampleNode)
+        val errorMessage = "Delete failed"
+        fakeNodeRepository.deleteNodeResult = Result.failure(Exception(errorMessage))
+
+        viewModel.deleteNode()
+
+        assertEquals(errorMessage, viewModel.error.value)
+        assertFalse(viewModel.isDeleted.value)
+        assertFalse(viewModel.isLoading.value)
     }
 }


### PR DESCRIPTION
## Summary
- `DetailViewModel` に投稿の編集・削除機能を追加
- `NodeRepository` / `NodeStore` に `updateNode` / `deleteNode` メソッドを追加
- `PUT /nodes/{id}` のレスポンス型を API 仕様に合わせて修正（`NodeDto` → `Unit`、更新後にgetNodeで再取得）
- 編集・削除の11テストケースを追加

## Changes
| Layer | File | Change |
|-------|------|--------|
| DataSource | `NodeDataSource.kt` | `updateNode` の返り値を `Unit` に修正 |
| DataSource | `KtorNodeDataSource.kt` | 同上 |
| DataSource | `MockNodeDataSource.kt` | 同上 |
| Repository | `NodeRepository.kt` | `updateNode` / `deleteNode` 追加 |
| Repository | `NodeRepositoryImpl.kt` | 実装追加（PUT後にGETで再取得パターン） |
| Store | `NodeStore.kt` | `updateNode` / `removeNode` 追加 |
| ViewModel | `DetailViewModel.kt` | 編集モード + 削除機能追加 |
| Test | `FakeNodeRepository.kt` | Fake実装追加 |
| Test | `DetailViewModelTest.kt` | 11テストケース追加 |

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest` 通過（全テストパス）
- [x] `./gradlew :composeApp:assembleDebug` 通過
- [x] iOS側のUI実装（別PR）
- [ ] 実機で編集・削除の動作確認

closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)