### PR TITLE
fix: ホーム画面のタブフィルター重複を解消

### DIFF
--- a/iosApp/iosApp/HomeView.swift
+++ b/iosApp/iosApp/HomeView.swift
@@ -5,14 +5,14 @@ import KMPObservableViewModelSwiftUI
 // MARK: - Tab / Sort UI Enums
 
 enum HomeTabUI: String, CaseIterable {
-    case latest = "新着"
+    case all = "すべて"
     case issue = "課題"
     case idea = "アイデア"
     case mine = "自分"
 
     var kotlinTab: HomeTab {
         switch self {
-        case .latest: return .recent
+        case .all: return .all
         case .issue: return .issues
         case .idea: return .ideas
         case .mine: return .mine
@@ -21,11 +21,11 @@ enum HomeTabUI: String, CaseIterable {
 
     init(from kotlinTab: HomeTab) {
         switch kotlinTab {
-        case .recent: self = .latest
+        case .all: self = .all
         case .issues: self = .issue
         case .ideas: self = .idea
         case .mine: self = .mine
-        default: self = .latest
+        default: self = .all
         }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/store/NodeStore.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/store/NodeStore.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 enum class HomeTab {
-    RECENT, ISSUES, IDEAS, MINE
+    ALL, ISSUES, IDEAS, MINE
 }
 
 enum class SortOrder {
@@ -24,7 +24,7 @@ class NodeStore {
     private val _selectedNode = MutableStateFlow<Node?>(null)
     val selectedNode: StateFlow<Node?> = _selectedNode.asStateFlow()
 
-    private val _currentTab = MutableStateFlow(HomeTab.RECENT)
+    private val _currentTab = MutableStateFlow(HomeTab.ALL)
     val currentTab: StateFlow<HomeTab> = _currentTab.asStateFlow()
 
     private val _sortOrder = MutableStateFlow(SortOrder.RECENT)
@@ -56,7 +56,7 @@ class NodeStore {
 
     fun getFilteredNodes(currentUserId: String? = null): List<Node> {
         val filtered = when (_currentTab.value) {
-            HomeTab.RECENT -> _nodes.value
+            HomeTab.ALL -> _nodes.value
             HomeTab.ISSUES -> _nodes.value.filter { it.type == NodeType.ISSUE }
             HomeTab.IDEAS -> _nodes.value.filter { it.type == NodeType.IDEA }
             HomeTab.MINE -> if (currentUserId != null) {
@@ -79,7 +79,7 @@ class NodeStore {
         _nodes.value = emptyList()
         _isLoading.value = false
         _selectedNode.value = null
-        _currentTab.value = HomeTab.RECENT
+        _currentTab.value = HomeTab.ALL
         _sortOrder.value = SortOrder.RECENT
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/HomeViewModel.kt
@@ -34,7 +34,7 @@ class HomeViewModel(
     @NativeCoroutinesState
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
-    private val _currentTab = MutableStateFlow(viewModelScope, HomeTab.RECENT)
+    private val _currentTab = MutableStateFlow(viewModelScope, HomeTab.ALL)
     @NativeCoroutinesState
     val currentTab: StateFlow<HomeTab> = _currentTab.asStateFlow()
 

--- a/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/HomeViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/HomeViewModelTest.kt
@@ -148,12 +148,12 @@ class HomeViewModelTest : MainDispatcherRule() {
     }
 
     @Test
-    fun `setTab - RECENTタブで全ノードが表示されること`() = runTest {
+    fun `setTab - ALLタブで全ノードが表示されること`() = runTest {
         fakeNodeRepository.getNodesResult = Result.success(sampleNodes)
         viewModel.loadNodes()
         viewModel.setTab(HomeTab.ISSUES)
 
-        viewModel.setTab(HomeTab.RECENT)
+        viewModel.setTab(HomeTab.ALL)
 
         assertEquals(sampleNodes.size, viewModel.nodes.value.size)
     }
@@ -220,9 +220,9 @@ class HomeViewModelTest : MainDispatcherRule() {
     }
 
     @Test
-    fun `初期状態 - ノードが空で、タブがRECENTであること`() = runTest {
+    fun `初期状態 - ノードが空で、タブがALLであること`() = runTest {
         assertTrue(viewModel.nodes.value.isEmpty())
-        assertEquals(HomeTab.RECENT, viewModel.currentTab.value)
+        assertEquals(HomeTab.ALL, viewModel.currentTab.value)
         assertEquals(SortOrder.RECENT, viewModel.sortOrder.value)
         assertFalse(viewModel.isLoading.value)
         assertNull(viewModel.error.value)


### PR DESCRIPTION
## Summary

- `HomeTab.RECENT` を `HomeTab.ALL` にリネームし、タブラベルを「新着」→「すべて」に変更
- タブ = コンテンツフィルタリング（何を見るか）、ソート = 表示順序（どの順で見るか）の役割を明確化
- ソートメニュー（新しい順/人気順）は維持

Closes #45

## Test plan

- [x] shared層テスト全パス
- [x] iOSビルド成功
- [ ] ホーム画面のタブが「すべて | 課題 | アイデア | 自分」になっていること
- [ ] 「すべて」タブで全投稿が表示されること
- [ ] ソートメニュー（新しい順/人気順）が引き続き動作すること
- [ ] タブ切り替え後にソートが正しく適用されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)