### PR TITLE
feat(ios): 投稿の編集・削除UIを追加 (#40)

### DIFF
--- a/iosApp/iosApp/DetailView.swift
+++ b/iosApp/iosApp/DetailView.swift
@@ -10,13 +10,28 @@ struct DetailView: View {
     let nodeId: String
     @StateViewModel var viewModel = KoinHelper().getDetailViewModel()
     @State private var showDerivedPost = false
+    @State private var showDeleteAlert = false
     @Environment(\.isAuthenticated) private var isAuthenticated
+    @Environment(\.currentUserId) private var currentUserId
     @Environment(\.loginRequired) private var loginRequired
+    @Environment(\.dismiss) private var dismiss
+
+    private var isOwner: Bool {
+        guard let userId = currentUserId,
+              let node = viewModel.selectedNode else { return false }
+        return node.authorId == userId
+    }
 
     var body: some View {
         Group {
-            if let node = viewModel.selectedNode {
-                nodeDetailContent(node: node)
+            if viewModel.isDeleted as? Bool == true {
+                deletedView
+            } else if let node = viewModel.selectedNode {
+                if viewModel.isEditing as? Bool == true {
+                    editingContent(node: node)
+                } else {
+                    nodeDetailContent(node: node)
+                }
             } else if let error = viewModel.error {
                 VStack(spacing: 16) {
                     Image(systemName: "exclamationmark.triangle")
@@ -34,12 +49,137 @@ struct DetailView: View {
                 ProgressView("読み込み中...")
             }
         }
-        .navigationTitle("詳細")
+        .navigationTitle(viewModel.isEditing as? Bool == true ? "編集" : "詳細")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if isOwner && viewModel.isEditing as? Bool != true && viewModel.isDeleted as? Bool != true {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Menu {
+                        Button(action: { viewModel.startEditing() }) {
+                            Label("編集", systemImage: "pencil")
+                        }
+                        Button(role: .destructive, action: { showDeleteAlert = true }) {
+                            Label("削除", systemImage: "trash")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                }
+            }
+            if viewModel.isEditing as? Bool == true {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("キャンセル") {
+                        viewModel.cancelEditing()
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("保存") {
+                        viewModel.saveEdit()
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(
+                        (viewModel.editTitle as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || viewModel.isLoading as? Bool == true
+                    )
+                }
+            }
+        }
+        .alert("投稿を削除", isPresented: $showDeleteAlert) {
+            Button("キャンセル", role: .cancel) {}
+            Button("削除", role: .destructive) {
+                viewModel.deleteNode()
+            }
+        } message: {
+            Text("この投稿を削除しますか？この操作は取り消せません。")
+        }
         .onAppear {
             viewModel.loadDetail(nodeId: nodeId)
         }
     }
+
+    // MARK: - Deleted View
+
+    private var deletedView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundColor(.green)
+            Text("投稿を削除しました")
+                .font(.headline)
+            Button("戻る") {
+                dismiss()
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    // MARK: - Editing Content
+
+    private func editingContent(node: Node) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                // Type badge (read-only)
+                HStack(spacing: 8) {
+                    Image(systemName: NodeTypeStyle.icon(for: node.type))
+                        .foregroundColor(NodeTypeStyle.color(for: node.type))
+                    Text(NodeTypeStyle.label(for: node.type))
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundColor(NodeTypeStyle.color(for: node.type))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(NodeTypeStyle.backgroundColor(for: node.type))
+                        .cornerRadius(4)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("タイトル")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.secondary)
+                    TextField("タイトル", text: Binding(
+                        get: { viewModel.editTitle as? String ?? "" },
+                        set: { viewModel.updateEditTitle(title: $0) }
+                    ))
+                    .textFieldStyle(.roundedBorder)
+                    .font(.body)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("内容")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.secondary)
+                    TextEditor(text: Binding(
+                        get: { viewModel.editContent as? String ?? "" },
+                        set: { viewModel.updateEditContent(content: $0) }
+                    ))
+                    .frame(minHeight: 200)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color(.systemGray4), lineWidth: 1)
+                    )
+                }
+
+                if let error = viewModel.error {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+
+                if viewModel.isLoading as? Bool == true {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    // MARK: - Detail Content
 
     private func nodeDetailContent(node: Node) -> some View {
         ScrollView {

--- a/iosApp/iosApp/RootView.swift
+++ b/iosApp/iosApp/RootView.swift
@@ -12,6 +12,10 @@ private struct LoginRequiredActionKey: EnvironmentKey {
     static let defaultValue: () -> Void = {}
 }
 
+private struct CurrentUserIdKey: EnvironmentKey {
+    static let defaultValue: String? = nil
+}
+
 extension EnvironmentValues {
     var isAuthenticated: Bool {
         get { self[IsAuthenticatedKey.self] }
@@ -21,6 +25,11 @@ extension EnvironmentValues {
     var loginRequired: () -> Void {
         get { self[LoginRequiredActionKey.self] }
         set { self[LoginRequiredActionKey.self] = newValue }
+    }
+
+    var currentUserId: String? {
+        get { self[CurrentUserIdKey.self] }
+        set { self[CurrentUserIdKey.self] = newValue }
     }
 }
 
@@ -42,6 +51,7 @@ struct RootView: View {
             }
         )
         .environment(\.isAuthenticated, isAuth)
+        .environment(\.currentUserId, (viewModel.currentUser as? User)?.id)
         .environment(\.loginRequired, { showLoginSheet = true })
         .sheet(isPresented: $showLoginSheet) {
             NavigationStack {


### PR DESCRIPTION
## Summary
- DetailViewにtoolbarメニュー（編集/削除）を追加。自分の投稿のみ表示
- 編集モード: タイトル・内容のインライン編集UI、toolbar保存/キャンセルボタン
- 削除: 確認Alert + 削除成功画面
- RootViewに`currentUserId`環境変数を追加し、投稿者判定に使用

## Dependencies
- PR #63 (shared層: DetailViewModel edit/delete API) のマージが先に必要

## Test plan
- [x] iOSビルド成功
- [x] 自分の投稿の詳細画面で`...`メニューが表示される
- [x] 他人の投稿ではメニューが非表示
- [x] 編集モードでタイトル/内容を変更して保存できる
- [x] 空タイトルでは保存ボタンが無効
- [x] 削除確認Alertが表示される
- [x] 削除成功後に完了メッセージが表示される

## 動作確認用
```bash
open ~/.claude-worktrees/inspirehub-mobile/feat/phase1-3-edit-delete-ios/iosApp/iosApp.xcodeproj
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)