### PR TITLE
fix(shared): API仕様との差異を修正（8件のデシリアライズ不具合解消）

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/AuthMeResponseDto.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/AuthMeResponseDto.kt
@@ -1,0 +1,12 @@
+package io.github.witsisland.inspirehub.data.dto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * GET /auth/me のレスポンスラッパー
+ * API: { "user": UserDto }
+ */
+@Serializable
+data class AuthMeResponseDto(
+    val user: UserDto
+)

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/CommentDetailResponseDto.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/CommentDetailResponseDto.kt
@@ -1,0 +1,12 @@
+package io.github.witsisland.inspirehub.data.dto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * GET /comments/{id} のレスポンスラッパー
+ * API: { "comment": CommentDto }
+ */
+@Serializable
+data class CommentDetailResponseDto(
+    val comment: CommentDto
+)

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/CommentDto.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/CommentDto.kt
@@ -10,14 +10,14 @@ data class CommentDto(
     @SerialName("author_id")
     val authorId: String,
     @SerialName("author_name")
-    val authorName: String = "",
+    val authorName: String? = null,
     @SerialName("author_picture")
     val authorPicture: String? = null,
     @SerialName("node_id")
     val nodeId: String,
     @SerialName("parent_id")
     val parentId: String? = null,
-    val mentions: List<String> = emptyList(),
+    val mentions: List<MentionDto> = emptyList(),
     val replies: List<CommentDto> = emptyList(),
     @SerialName("created_at")
     val createdAt: String,

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/CreateCommentResponseDto.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/CreateCommentResponseDto.kt
@@ -1,0 +1,13 @@
+package io.github.witsisland.inspirehub.data.dto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * POST /nodes/{nodeId}/comments のレスポンス (201 Created)
+ * API: { "id": string, "message": string }
+ */
+@Serializable
+data class CreateCommentResponseDto(
+    val id: String,
+    val message: String
+)

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/MentionDto.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/MentionDto.kt
@@ -1,0 +1,14 @@
+package io.github.witsisland.inspirehub.data.dto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * コメント内のメンションユーザー
+ * API: { "id": string, "name": string, "picture": string | null }
+ */
+@Serializable
+data class MentionDto(
+    val id: String,
+    val name: String,
+    val picture: String? = null
+)

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/NodeDto.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/NodeDto.kt
@@ -12,7 +12,7 @@ data class NodeDto(
     @SerialName("author_id")
     val authorId: String,
     @SerialName("author_name")
-    val authorName: String = "",
+    val authorName: String? = null,
     @SerialName("author_picture")
     val authorPicture: String? = null,
     @SerialName("parent_node")

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/TokenResponseDto.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/dto/TokenResponseDto.kt
@@ -14,5 +14,5 @@ data class TokenResponseDto(
     val refreshToken: String,
     @SerialName("expires_in")
     val expiresIn: Int,
-    val user: UserDto
+    val user: UserDto? = null
 )

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/mapper/CommentMapper.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/mapper/CommentMapper.kt
@@ -9,10 +9,10 @@ fun CommentDto.toDomain(): Comment {
         nodeId = nodeId,
         parentId = parentId,
         authorId = authorId,
-        authorName = authorName,
+        authorName = authorName ?: "",
         authorPicture = authorPicture,
         content = content,
-        mentions = mentions,
+        mentions = mentions.map { it.name },
         replies = replies.map { it.toDomain() },
         createdAt = createdAt
     )

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/mapper/NodeMapper.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/mapper/NodeMapper.kt
@@ -22,7 +22,7 @@ fun NodeDto.toDomain(): Node {
         title = title,
         content = content ?: "",
         authorId = authorId,
-        authorName = authorName,
+        authorName = authorName ?: "",
         authorPicture = authorPicture,
         parentNode = parentNode?.toDomain(),
         tagIds = tags.map { it.name },

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/network/HttpClientFactory.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/network/HttpClientFactory.kt
@@ -49,6 +49,7 @@ fun HttpClient.configureClient(
                 prettyPrint = true
                 isLenient = true
                 ignoreUnknownKeys = true
+                coerceInputValues = true
             })
         }
 

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/AuthRepositoryImpl.kt
@@ -22,7 +22,9 @@ class AuthRepositoryImpl(
     override suspend fun verifyGoogleToken(idToken: String): Result<User> {
         return try {
             val tokenResponse = authDataSource.verifyGoogleToken(idToken)
-            val user = tokenResponse.user.toDomain()
+            val userDto = tokenResponse.user
+                ?: return Result.failure(IllegalStateException("ユーザー情報が含まれていません"))
+            val user = userDto.toDomain()
 
             log.d { "Access token: ${tokenResponse.accessToken}" }
 

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/CommentRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/repository/CommentRepositoryImpl.kt
@@ -30,10 +30,10 @@ class CommentRepositoryImpl(
         nodeId: String,
         content: String,
         parentId: String?
-    ): Result<Comment> {
+    ): Result<String> {
         return try {
-            val dto = dataSource.createComment(nodeId, content, parentId)
-            Result.success(dto.toDomain())
+            val commentId = dataSource.createComment(nodeId, content, parentId)
+            Result.success(commentId)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/CommentDataSource.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/CommentDataSource.kt
@@ -29,12 +29,13 @@ interface CommentDataSource {
      * @param nodeId ノードID
      * @param content コメント内容
      * @param parentId 返信先コメントID（nullの場合は新規コメント）
+     * @return 作成されたコメントのID
      */
     suspend fun createComment(
         nodeId: String,
         content: String,
         parentId: String? = null
-    ): CommentDto
+    ): String
 
     /**
      * コメントを更新
@@ -44,7 +45,7 @@ interface CommentDataSource {
     suspend fun updateComment(
         id: String,
         content: String
-    ): CommentDto
+    )
 
     /**
      * コメントを削除

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/KtorAuthDataSource.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/KtorAuthDataSource.kt
@@ -1,6 +1,7 @@
 package io.github.witsisland.inspirehub.data.source
 
 import co.touchlab.kermit.Logger
+import io.github.witsisland.inspirehub.data.dto.AuthMeResponseDto
 import io.github.witsisland.inspirehub.data.dto.TokenResponseDto
 import io.github.witsisland.inspirehub.data.dto.UserDto
 import io.github.witsisland.inspirehub.data.dto.UserUpdateResponseDto
@@ -40,7 +41,8 @@ class KtorAuthDataSource(
     }
 
     override suspend fun getCurrentUser(): UserDto {
-        return httpClient.get("/auth/me").body()
+        val response: AuthMeResponseDto = httpClient.get("/auth/me").body()
+        return response.user
     }
 
     override suspend fun logout() {

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/KtorCommentDataSource.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/KtorCommentDataSource.kt
@@ -1,8 +1,10 @@
 package io.github.witsisland.inspirehub.data.source
 
+import io.github.witsisland.inspirehub.data.dto.CommentDetailResponseDto
 import io.github.witsisland.inspirehub.data.dto.CommentDto
 import io.github.witsisland.inspirehub.data.dto.CommentsResponseDto
 import io.github.witsisland.inspirehub.data.dto.CreateCommentRequestDto
+import io.github.witsisland.inspirehub.data.dto.CreateCommentResponseDto
 import io.github.witsisland.inspirehub.data.dto.UpdateCommentRequestDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -42,44 +44,46 @@ class KtorCommentDataSource(
 
     /**
      * GET /comments/{id}
-     * Response: CommentDto（直接）
+     * Response: { "comment": CommentDto }
      */
     override suspend fun getComment(id: String): CommentDto {
-        return httpClient.get("/comments/$id").body()
+        val response: CommentDetailResponseDto = httpClient.get("/comments/$id").body()
+        return response.comment
     }
 
     /**
      * POST /nodes/{nodeId}/comments
      * Request: CreateCommentRequestDto
-     * Response: CommentDto
+     * Response: { "id": string, "message": string } (201 Created)
      */
     override suspend fun createComment(
         nodeId: String,
         content: String,
         parentId: String?
-    ): CommentDto {
-        return httpClient.post("/nodes/$nodeId/comments") {
+    ): String {
+        val response: CreateCommentResponseDto = httpClient.post("/nodes/$nodeId/comments") {
             contentType(ContentType.Application.Json)
             setBody(CreateCommentRequestDto(
                 content = content,
                 parentId = parentId
             ))
         }.body()
+        return response.id
     }
 
     /**
      * PUT /comments/{id}
      * Request: UpdateCommentRequestDto
-     * Response: CommentDto
+     * Response: { "message": string }
      */
     override suspend fun updateComment(
         id: String,
         content: String
-    ): CommentDto {
-        return httpClient.put("/comments/$id") {
+    ) {
+        httpClient.put("/comments/$id") {
             contentType(ContentType.Application.Json)
             setBody(UpdateCommentRequestDto(content = content))
-        }.body()
+        }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/MockCommentDataSource.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/data/source/MockCommentDataSource.kt
@@ -29,9 +29,10 @@ class MockCommentDataSource : CommentDataSource {
         nodeId: String,
         content: String,
         parentId: String?
-    ): CommentDto {
+    ): String {
+        val id = "comment_${nextId++}"
         val newComment = CommentDto(
-            id = "comment_${nextId++}",
+            id = id,
             content = content,
             authorId = "user_mock",
             authorName = "テストユーザー",
@@ -44,17 +45,16 @@ class MockCommentDataSource : CommentDataSource {
             updatedAt = "2026-02-02T00:00:00Z"
         )
         comments.add(newComment)
-        return newComment
+        return id
     }
 
-    override suspend fun updateComment(id: String, content: String): CommentDto {
+    override suspend fun updateComment(id: String, content: String) {
         val index = comments.indexOfFirst { it.id == id }
         val updated = comments[index].copy(
             content = content,
             updatedAt = "2026-02-02T00:00:01Z"
         )
         comments[index] = updated
-        return updated
     }
 
     override suspend fun deleteComment(id: String) {

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/repository/CommentRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/domain/repository/CommentRepository.kt
@@ -24,12 +24,13 @@ interface CommentRepository {
      * @param nodeId ノードID
      * @param content コメント内容
      * @param parentId 返信先コメントID（nullの場合は新規コメント）
+     * @return 作成されたコメントのID
      */
     suspend fun createComment(
         nodeId: String,
         content: String,
         parentId: String? = null
-    ): Result<Comment>
+    ): Result<String>
 
     /**
      * コメントを削除

--- a/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/DetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/DetailViewModel.kt
@@ -193,8 +193,10 @@ class DetailViewModel(
             )
 
             if (result.isSuccess) {
-                result.getOrNull()?.let { comment ->
-                    _comments.value = (_comments.value + comment)
+                // コメント一覧を再取得して最新状態を反映
+                val commentsResult = commentRepository.getComments(nodeId)
+                if (commentsResult.isSuccess) {
+                    _comments.value = (commentsResult.getOrNull() ?: emptyList())
                         .sortedByDescending { it.createdAt }
                 }
             } else {

--- a/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/domain/repository/FakeCommentRepository.kt
+++ b/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/domain/repository/FakeCommentRepository.kt
@@ -12,7 +12,7 @@ class FakeCommentRepository : CommentRepository {
 
     // 各メソッドの戻り値（nullの場合はcommentsリストから自動生成）
     var getCommentsResult: Result<List<Comment>>? = null
-    var createCommentResult: Result<Comment>? = null
+    var createCommentResult: Result<String>? = null
     var deleteCommentResult: Result<Unit>? = null
 
     // エラーシミュレート用フラグ
@@ -48,14 +48,14 @@ class FakeCommentRepository : CommentRepository {
         nodeId: String,
         content: String,
         parentId: String?
-    ): Result<Comment> {
+    ): Result<String> {
         createCommentCallCount++
         lastCreateCommentNodeId = nodeId
         lastCreateCommentContent = content
         lastCreateCommentParentId = parentId
 
         if (shouldReturnError) return Result.failure(Exception(errorMessage))
-        return createCommentResult ?: error("createCommentResult not set")
+        return createCommentResult ?: Result.success("comment_new")
     }
 
     override suspend fun deleteComment(id: String): Result<Unit> {

--- a/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/DetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/witsisland/inspirehub/presentation/viewmodel/DetailViewModelTest.kt
@@ -227,7 +227,9 @@ class DetailViewModelTest : MainDispatcherRule() {
             content = "新しいコメント",
             createdAt = "2026-01-22T09:00:00Z"
         )
-        fakeCommentRepository.createCommentResult = Result.success(newComment)
+        fakeCommentRepository.createCommentResult = Result.success("comment_new")
+        // submitComment成功後にgetCommentsが呼ばれるので、再取得結果を設定
+        fakeCommentRepository.comments.add(newComment)
 
         viewModel.submitComment()
 


### PR DESCRIPTION
## Summary

- API設計書（https://api.inspirehub.wtnqk.org/docs）とKtor DataSource実装を突合し、**8件の不整合を発見・修正**
- Critical 6件（デシリアライズ失敗）、Medium 1件（null安全性）、Low 1件（Json設定）
- shared層テスト・Android・iOSビルド全PASS

Closes #43

## 発見・修正した問題

| # | 重大度 | 問題 | 修正 |
|---|--------|------|------|
| 1 | Critical | `GET /auth/me` レスポンスラッパー `{user:{...}}` 未対応 | `AuthMeResponseDto` 追加 |
| 2 | Critical | `POST /auth/refresh` に `user` がないのに必須で期待 | `TokenResponseDto.user` nullable化 |
| 3 | Critical | `GET /comments/{id}` レスポンスラッパー未対応 | `CommentDetailResponseDto` 追加 |
| 4 | Critical | `POST /nodes/{id}/comments` レスポンス型不一致 | `CreateCommentResponseDto` 追加、成功後に一覧再取得 |
| 5 | Critical | `PUT /comments/{id}` レスポンス型不一致 | 戻り値を `Unit` に変更 |
| 6 | Critical | `CommentDto.mentions` 型不一致 | `MentionDto` 追加 |
| 7 | Medium | `authorName` non-null だがAPI nullable | nullable化 |
| 8 | Low | `coerceInputValues` 未設定 | Json設定に追加 |

## サーバチーム確認事項

- `GET /nodes` の `reacted` クエリパラメータがAPIドキュメントに存在しない（`KtorNodeDataSource.getReactedNodes` で送信中）。サーバ側での対応状況要確認。

## Test plan

- [x] shared層テスト: `./gradlew :shared:testDebugUnitTest` PASS
- [x] Androidビルド: `./gradlew :composeApp:assembleDebug` PASS
- [x] iOSビルド: xcodebuild PASS
- [x] 認証フロー（ログイン→/auth/me→プロフィール表示）
- [x] コメント投稿→一覧表示
- [x] コメント編集・削除

```bash
# 動作確認用
open ~/.claude-worktrees/inspirehub-mobile/fix/issue-43-api-integration-qa/iosApp/iosApp.xcodeproj
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)