### PR TITLE
feat: /implement スキル追加（Issue駆動実装フロー）

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -241,36 +241,10 @@ struct HomeView: View {
    - エージェントチームの作業効率よりも、機能単位の分割を優先する
    - 既存PRに無関係な機能を相乗りさせない
 
-## GitHub Actions（Issue駆動開発）ルール
+## GitHub Actions（Issue駆動開発）
 
-GitHub IssueからClaude Codeが起動された場合、以下のフローに従うこと。
-
-### 意図の判定
-
-まずIssueやコメントの内容を分析し、意図を判定する。
-
-- **質問・相談** → Issueコメントで回答して終了（Plan作成・ブランチ作成は不要）
-- **実装依頼** → 以下の実装フローに従う
-
-### 実装フロー
-
-1. **Plan作成**: Issueの内容を分析し、`.claude/plans/issue-{number}.md` にPlanファイルを作成
-2. **承認待ち**: PlanをIssueコメントとして投稿し、ユーザーの承認を待つ。承認前に実装を開始しない
-3. **ブランチ作成**: 承認後、`claude/issue-{number}` ブランチを作成して実装開始
-4. **shared層テスト**: `./gradlew :shared:testDebugUnitTest` を実行し、テストが通ることを確認
-5. **PR作成**: PRを作成。本文に `Closes #{issue番号}` を含める
-6. **タグpush**: PR作成後、`dev/pr-{PR番号}` タグをpushする（Xcode Cloud Dev版ビルド＆TestFlight配信トリガー）
-7. **Planファイル削除**: 実装完了後、`.claude/plans/issue-{number}.md` を削除してコミット
-
-### ブランチ命名
-
-- `claude/issue-{number}` （例: `claude/issue-42`）
-- 1 Issue = 1 ブランチ。やり直しの場合はブランチを削除して同名で再作成
-
-### iOSビルドについて
-
-- Claude CodeはiOSビルドを実行しない（Linux上で動作するため）
-- iOSの動作確認はXcode Cloud → TestFlight配信後に人間が行う
+GitHub IssueやPRコメントで `@claude` メンションするとClaude Codeが起動する。
+実装を依頼する場合は `@claude /implement` を使うこと（Plan作成→承認→実装→PR→TestFlight配信の一連フローが実行される）。
 
 ## 依存関係
 
@@ -353,6 +327,7 @@ Task toolでspawnして使用。
 
 | コマンド | 用途 |
 | ------- | ---- |
+| /implement | Issue駆動実装（Plan→承認→PR→TestFlight配信） |
 | /qa-check [BUG-ID\|all] | QAチェックリスト検証 |
 | /build-check [ios\|android\|shared\|all] | ビルド実行・エラー報告 |
 | /fix-bug \<BUG-ID\> | バグ自動修正 |

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: implement
+description: GitHub IssueからPlan作成→承認→ブランチ作成→実装→PR→TestFlight配信タグまでの一連フローを実行する
+user-invocable: true
+argument-hint: "(Issueの内容に従って実装を進める)"
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, WebSearch, WebFetch
+---
+
+# /implement — Issue駆動実装スキル
+
+GitHub IssueからClaude Codeが実装を行う際の標準フロー。
+
+## フロー
+
+### 1. Plan作成
+
+- Issueの内容を分析し、`.claude/plans/issue-{number}.md` にPlanファイルを作成
+- Plan内容:
+  - 変更対象ファイル一覧
+  - 実装方針
+  - 影響範囲
+  - テスト方針
+
+### 2. 承認待ち
+
+- PlanをIssueコメントとして投稿する
+- **承認前に実装を開始しない**
+- ユーザーから承認コメント（「OK」「LGTM」「進めて」等）があるまで待機
+
+### 3. ブランチ作成
+
+- `claude/issue-{number}` ブランチを作成して実装開始
+- 1 Issue = 1 ブランチ
+- やり直しの場合はブランチを削除して同名で再作成
+
+### 4. 実装
+
+- CLAUDE.mdおよび `.claude/rules/` のルールに従って実装
+- コミットメッセージはConventional Commits準拠
+- コミットメッセージに `Closes #{issue番号}` を含める
+
+### 5. shared層テスト
+
+- `./gradlew :shared:testDebugUnitTest` を実行
+- テストが通ることを確認してからPR作成に進む
+
+### 6. PR作成
+
+- PRを作成
+- 本文に `Closes #{issue番号}` を含める
+- 変更内容のSummaryとTest planを記載
+
+### 7. タグpush
+
+- PR作成後、`dev/pr-{PR番号}` タグをpushする
+- このタグがXcode Cloud Dev版ビルド＆TestFlight配信のトリガーになる
+
+### 8. Planファイル削除
+
+- `.claude/plans/issue-{number}.md` を削除してコミット
+
+## 注意事項
+
+- **iOSビルドは実行しない**（GitHub Actions上のLinuxで動作するため）
+- iOSの動作確認はXcode Cloud → TestFlight配信後に人間が行う
+- shared層の変更がなくてもタグpushは必ず行う（iOSへの影響確認のため）


### PR DESCRIPTION
## Summary

- `/implement` スキルを新規作成：GitHub IssueからのPlan→承認→実装→PR→TestFlight配信の一連フロー
- CLAUDE.mdの詳細フロー記述を削除し、スキル参照に簡素化

## 変更内容

- `.claude/skills/implement/SKILL.md`: 実装フロー全体を定義
- `.claude/CLAUDE.md`: GitHub Actionsセクションを2行に簡素化、スキル一覧に `/implement` 追加

## 使い方

```
@claude /implement この機能を実装して
```

質問・相談は今まで通り `@claude` だけでOK。実装依頼時のみ `/implement` をつける。

## Test plan

- [x] GitHub Issueで `@claude /implement` を試行し、Plan作成→Issueコメント投稿まで動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)