### PR TITLE
fix: XcodeビルドスクリプトにJAVA_HOMEを設定してJava Runtime未検出エラーを解消

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -185,7 +185,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/zsh;
-			shellScript = "# JAVA_HOMEの認識エラーで/bin/zshで実行\n# 参考：https://qiita.com/nacho4d/items/6d04c9287c55c26fca95\n\nif [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\n\ncd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
+			shellScript = "# JAVA_HOMEの認識エラーで/bin/zshで実行\n# 参考：https://qiita.com/nacho4d/items/6d04c9287c55c26fca95\n\n# Android Studio組み込みJDKをJAVA_HOMEに設定\nexport JAVA_HOME=\"/Applications/Android Studio.app/Contents/jbr/Contents/Home\"\n\nif [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\n\ncd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Summary

- Xcode のビルドスクリプト実行環境は PATH が最小限のため、システムに Java が登録されていても検出できない
- `Compile Kotlin Framework` スクリプトフェーズに Android Studio 同梱の OpenJDK 21 を `JAVA_HOME` として明示的に設定

## 変更箇所

`iosApp/iosApp.xcodeproj/project.pbxproj` のシェルスクリプトに以下を追加：
```bash
export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
```

## Test plan

- [ ] Xcode でビルドし `Unable to locate a Java Runtime.` が出ないことを確認
- [ ] Kotlin Framework のビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)