### PR TITLE
feat(android): BottomNavigation + MainScreen基盤を実装

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/MainScreen.kt
@@ -1,0 +1,255 @@
+package io.github.witsisland.inspirehub.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import io.github.witsisland.inspirehub.presentation.viewmodel.AuthViewModel
+import io.github.witsisland.inspirehub.ui.screen.DetailScreen
+import kotlinx.serialization.Serializable
+
+// ---------------------------------------------------------------------------
+// ナビゲーションルート定義
+// ---------------------------------------------------------------------------
+
+/** ホーム画面ルート */
+@Serializable
+object HomeRoute
+
+/** ディスカバー画面ルート */
+@Serializable
+object DiscoverRoute
+
+/** マイページ画面ルート */
+@Serializable
+object MyPageRoute
+
+/** 詳細画面ルート */
+@Serializable
+data class DetailRoute(val nodeId: String)
+
+// ---------------------------------------------------------------------------
+// タブ定義
+// ---------------------------------------------------------------------------
+
+/** ボトムナビゲーションのタブアイテム */
+private enum class BottomTab(
+    val label: String,
+    val icon: @Composable () -> Unit,
+    val route: String,
+) {
+    Home(
+        label = "ホーム",
+        icon = { Icon(Icons.Default.Home, contentDescription = "ホーム") },
+        route = "home",
+    ),
+    Discover(
+        label = "ディスカバー",
+        icon = { Icon(Icons.Default.Search, contentDescription = "ディスカバー") },
+        route = "discover",
+    ),
+    MyPage(
+        label = "マイページ",
+        icon = { Icon(Icons.Default.Person, contentDescription = "マイページ") },
+        route = "mypage",
+    ),
+}
+
+// ---------------------------------------------------------------------------
+// MainScreen
+// ---------------------------------------------------------------------------
+
+/**
+ * アプリのメイン画面。
+ *
+ * BottomNavigation（3タブ）+ FAB + NavHostを持つ基盤画面。
+ * FABはホームとディスカバータブでのみ表示される。
+ *
+ * - Note: showPostTypeSheet は後続PR（投稿フロー）で利用する
+ */
+@Composable
+fun MainScreen(
+    authViewModel: AuthViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    /** 投稿タイプ選択シート表示フラグ（後続PRで実装） */
+    var showPostTypeSheet by remember { mutableStateOf(false) }
+
+    /** FABを表示するタブかどうか */
+    val isFabVisible = currentRoute in listOf(BottomTab.Home.route, BottomTab.Discover.route)
+
+    Scaffold(
+        modifier = modifier,
+        bottomBar = {
+            MainBottomBar(
+                navController = navController,
+                currentRoute = currentRoute,
+            )
+        },
+        floatingActionButton = {
+            if (isFabVisible) {
+                FloatingActionButton(
+                    onClick = { showPostTypeSheet = true },
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = "投稿")
+                }
+            }
+        },
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = BottomTab.Home.route,
+            modifier = Modifier.padding(innerPadding),
+        ) {
+            composable(BottomTab.Home.route) {
+                HomeScreenPlaceholder()
+            }
+            composable(BottomTab.Discover.route) {
+                DiscoverScreenPlaceholder()
+            }
+            composable(BottomTab.MyPage.route) {
+                MyPageScreenPlaceholder(
+                    onLogout = { authViewModel.logout() },
+                )
+            }
+            composable(
+                route = "detail/{nodeId}",
+                arguments = listOf(navArgument("nodeId") { type = NavType.StringType }),
+            ) { backStackEntry ->
+                val nodeId = backStackEntry.arguments?.getString("nodeId") ?: return@composable
+                DetailScreen(
+                    nodeId = nodeId,
+                    onNodeClick = { childId ->
+                        navController.navigate("detail/$childId")
+                    },
+                    onBack = { navController.popBackStack() },
+                )
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BottomBar
+// ---------------------------------------------------------------------------
+
+/**
+ * メイン画面のボトムナビゲーションバー。
+ */
+@Composable
+private fun MainBottomBar(
+    navController: NavController,
+    currentRoute: String?,
+) {
+    NavigationBar {
+        BottomTab.entries.forEach { tab ->
+            NavigationBarItem(
+                selected = currentRoute == tab.route,
+                onClick = {
+                    navController.navigate(tab.route) {
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                icon = tab.icon,
+                label = { Text(tab.label) },
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// プレースホルダー画面（後続PRで差し替え）
+// ---------------------------------------------------------------------------
+
+/**
+ * ホーム画面のプレースホルダー。
+ *
+ * - Note: 後続PRで HomeScreen に差し替える
+ */
+@Composable
+fun HomeScreenPlaceholder() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "ホーム（実装中）",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * ディスカバー画面のプレースホルダー。
+ *
+ * - Note: 後続PRで DiscoverScreen に差し替える
+ */
+@Composable
+fun DiscoverScreenPlaceholder() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "ディスカバー（実装中）",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * マイページ画面のプレースホルダー。
+ *
+ * - Note: 後続PRで MyPageScreen に差し替える
+ */
+@Composable
+fun MyPageScreenPlaceholder(onLogout: () -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "マイページ（実装中）",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/RootScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/RootScreen.kt
@@ -1,19 +1,8 @@
 package io.github.witsisland.inspirehub.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import io.github.witsisland.inspirehub.presentation.viewmodel.AuthViewModel
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -22,36 +11,8 @@ fun RootScreen(authViewModel: AuthViewModel = koinViewModel()) {
     val isAuthenticated by authViewModel.isAuthenticated.collectAsState()
 
     if (isAuthenticated) {
-        // TODO: 足軽5がNavigation/MainScreen構築中。完成後に差し替え。
-        MainScreenPlaceholder(onLogout = { authViewModel.logout() })
+        MainScreen(authViewModel = authViewModel)
     } else {
         LoginScreen(viewModel = authViewModel)
-    }
-}
-
-/**
- * 仮のメイン画面（Navigation完成まで）
- */
-@Composable
-private fun MainScreenPlaceholder(onLogout: () -> Unit) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Text(
-            text = "ログイン成功！",
-            style = MaterialTheme.typography.headlineMedium
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "メイン画面は準備中です",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.height(32.dp))
-        OutlinedButton(onClick = onLogout) {
-            Text("ログアウト")
-        }
     }
 }


### PR DESCRIPTION
## 概要

Android Phase 1 基盤: BottomNavigation + MainScreen + FAB実装

## 変更内容

- `MainScreen.kt` 新規作成（3タブ + FAB + NavHost）
  - Material3 `Scaffold` + `NavigationBar` + `NavigationBarItem` で3タブ構成（ホーム/ディスカバー/マイページ）
  - `NavController` + `NavHost` で画面遷移管理
  - FABはホーム・ディスカバータブでのみ表示
  - `detail/{nodeId}` ルートで DetailScreen への遷移を定義
  - `showPostTypeSheet` State を用意（後続PRの投稿フローで使用）
  - 各タブはプレースホルダー Composable（後続PRで差し替え）
- `RootScreen.kt` 修正（`MainScreenPlaceholder` → `MainScreen` に置き換え）

## ナビゲーション設計

```
MainScreen
├── NavigationBar（3タブ）
│   ├── home → HomeScreenPlaceholder
│   ├── discover → DiscoverScreenPlaceholder
│   └── mypage → MyPageScreenPlaceholder
└── NavHost
    └── detail/{nodeId} → DetailScreen
```

## 後続PR依存

- PR-B（ホーム画面）、PR-C（投稿フロー）、PR-D（ディスカバー+マイページ）がこのPRのマージを待っています

## テスト

- [x] shared層テスト成功（`./gradlew :shared:testDebugUnitTest`）
- [x] Androidビルド成功（`./gradlew :composeApp:assembleDebug`）
- [ ] 3タブ切り替えが正常動作
- [ ] FABがホーム/ディスカバーのみ表示
- [ ] DetailScreenへの遷移が機能する

## 既存のビルド警告（このPRとは無関係）

- `DetailScreen.kt` の `Divider` → `HorizontalDivider` 非推奨 warning（既存コード）
- KMP + AGP互換性に関する deprecation warning（既存の設定）

🤖 Generated with Claude Code