### PR TITLE
feat(android): 投稿フロー実装（PostTypeSheet/課題・アイデア・派生投稿）

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/MainScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavType
@@ -32,6 +34,9 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import io.github.witsisland.inspirehub.presentation.viewmodel.AuthViewModel
 import io.github.witsisland.inspirehub.ui.screen.DetailScreen
+import io.github.witsisland.inspirehub.ui.screen.IdeaPostScreen
+import io.github.witsisland.inspirehub.ui.screen.IssuePostScreen
+import io.github.witsisland.inspirehub.ui.screen.PostTypeSelectSheet
 import kotlinx.serialization.Serializable
 
 // ---------------------------------------------------------------------------
@@ -90,8 +95,7 @@ private enum class BottomTab(
  *
  * BottomNavigation（3タブ）+ FAB + NavHostを持つ基盤画面。
  * FABはホームとディスカバータブでのみ表示される。
- *
- * - Note: showPostTypeSheet は後続PR（投稿フロー）で利用する
+ * FABタップでPostTypeSelectSheetを表示し、課題/アイデア投稿画面に遷移する。
  */
 @Composable
 fun MainScreen(
@@ -102,8 +106,14 @@ fun MainScreen(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
-    /** 投稿タイプ選択シート表示フラグ（後続PRで実装） */
+    /** 投稿タイプ選択シート表示フラグ */
     var showPostTypeSheet by remember { mutableStateOf(false) }
+
+    /** 課題投稿画面表示フラグ */
+    var showIssuePost by remember { mutableStateOf(false) }
+
+    /** アイデア投稿画面表示フラグ */
+    var showIdeaPost by remember { mutableStateOf(false) }
 
     /** FABを表示するタブかどうか */
     val isFabVisible = currentRoute in listOf(BottomTab.Home.route, BottomTab.Discover.route)
@@ -128,6 +138,45 @@ fun MainScreen(
             }
         },
     ) { innerPadding ->
+        // 投稿タイプ選択シート
+        if (showPostTypeSheet) {
+            PostTypeSelectSheet(
+                onDismiss = { showPostTypeSheet = false },
+                onIssueSelected = {
+                    showPostTypeSheet = false
+                    showIssuePost = true
+                },
+                onIdeaSelected = {
+                    showPostTypeSheet = false
+                    showIdeaPost = true
+                },
+            )
+        }
+
+        // 課題投稿画面（フルスクリーンダイアログ）
+        if (showIssuePost) {
+            Dialog(
+                onDismissRequest = { showIssuePost = false },
+                properties = DialogProperties(usePlatformDefaultWidth = false),
+            ) {
+                IssuePostScreen(
+                    onDismiss = { showIssuePost = false },
+                )
+            }
+        }
+
+        // アイデア投稿画面（フルスクリーンダイアログ）
+        if (showIdeaPost) {
+            Dialog(
+                onDismissRequest = { showIdeaPost = false },
+                properties = DialogProperties(usePlatformDefaultWidth = false),
+            ) {
+                IdeaPostScreen(
+                    onDismiss = { showIdeaPost = false },
+                )
+            }
+        }
+
         NavHost(
             navController = navController,
             startDestination = BottomTab.Home.route,

--- a/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/components/TagInputComponent.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/components/TagInputComponent.kt
@@ -1,0 +1,155 @@
+package io.github.witsisland.inspirehub.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.witsisland.inspirehub.domain.model.Tag
+
+/** タグ上限数 */
+private const val MAX_TAGS = 5
+
+/**
+ * タグ入力コンポーネント
+ *
+ * タグの入力・サジェスト表示・追加済みタグ一覧を提供する。
+ * タグは最大5個まで追加可能。
+ *
+ * - Note: onSearchSuggestions はユーザー入力のたびに呼ばれる。デバウンスはViewModel側で行う。
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun TagInputComponent(
+    /** 追加済みタグ一覧 */
+    tags: List<String>,
+    /** APIサジェスト候補一覧 */
+    tagSuggestions: List<Tag>,
+    /** タグ追加コールバック */
+    onAddTag: (String) -> Unit,
+    /** タグ削除コールバック */
+    onRemoveTag: (String) -> Unit,
+    /** サジェスト検索コールバック */
+    onSearchSuggestions: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var inputText by remember { mutableStateOf("") }
+    val isMaxTagsReached = tags.size >= MAX_TAGS
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // タグ入力フィールド
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedTextField(
+                value = inputText,
+                onValueChange = { newValue ->
+                    inputText = newValue
+                    onSearchSuggestions(newValue)
+                },
+                placeholder = { Text("タグを入力...") },
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                enabled = !isMaxTagsReached,
+                label = { Text("タグ（任意・最大${MAX_TAGS}個）") },
+            )
+            IconButton(
+                onClick = {
+                    val trimmed = inputText.trim()
+                    if (trimmed.isNotEmpty()) {
+                        onAddTag(trimmed)
+                        inputText = ""
+                        onSearchSuggestions("")
+                    }
+                },
+                enabled = inputText.trim().isNotEmpty() && !isMaxTagsReached,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AddCircle,
+                    contentDescription = "タグを追加",
+                    tint = if (inputText.trim().isNotEmpty() && !isMaxTagsReached) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                    },
+                    modifier = Modifier.size(28.dp),
+                )
+            }
+        }
+
+        // サジェスト候補（横スクロール）
+        if (tagSuggestions.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(tagSuggestions, key = { it.id }) { tag ->
+                    FilterChip(
+                        selected = false,
+                        onClick = {
+                            onAddTag(tag.name)
+                            inputText = ""
+                            onSearchSuggestions("")
+                        },
+                        label = { Text("#${tag.name}") },
+                        enabled = !isMaxTagsReached,
+                    )
+                }
+            }
+        }
+
+        // 追加済みタグ（FlowRow）
+        if (tags.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                tags.forEach { tag ->
+                    InputChip(
+                        selected = false,
+                        onClick = { },
+                        label = { Text("#$tag") },
+                        trailingIcon = {
+                            IconButton(
+                                onClick = { onRemoveTag(tag) },
+                                modifier = Modifier.size(18.dp),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Close,
+                                    contentDescription = "タグ「$tag」を削除",
+                                    modifier = Modifier.size(14.dp),
+                                )
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/screen/DerivedPostScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/screen/DerivedPostScreen.kt
@@ -1,0 +1,259 @@
+package io.github.witsisland.inspirehub.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.github.witsisland.inspirehub.domain.model.Node
+import io.github.witsisland.inspirehub.domain.model.NodeType
+import io.github.witsisland.inspirehub.presentation.viewmodel.PostViewModel
+import io.github.witsisland.inspirehub.ui.components.TagInputComponent
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * 派生投稿画面
+ *
+ * 既存ノードを派生元として引用し、新しいアイデアを投稿するフォーム画面。
+ * 派生元のタイトルを読み取り専用で表示する。
+ *
+ * - Note: 投稿完了後は onDismiss() を呼んで画面を閉じる
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DerivedPostScreen(
+    /** 派生元ノードのID */
+    parentNodeId: String,
+    /** 派生元ノードのタイトル */
+    parentNodeTitle: String,
+    /** 派生元ノードの種別（表示用アイコン切り替えに使用） */
+    parentNodeType: NodeType = NodeType.IDEA,
+    /** 画面を閉じるコールバック（完了・キャンセル共通） */
+    onDismiss: () -> Unit,
+    /** 派生投稿ViewModel */
+    viewModel: PostViewModel = koinViewModel(),
+) {
+    val title by viewModel.title.collectAsState()
+    val content by viewModel.content.collectAsState()
+    val tags by viewModel.tags.collectAsState()
+    val tagSuggestions by viewModel.suggestedTags.collectAsState()
+    val isSubmitting by viewModel.isSubmitting.collectAsState()
+    val isValid by viewModel.isValid.collectAsState()
+    val isSuccess by viewModel.isSuccess.collectAsState()
+
+    // 派生元ノードをViewModelにセット（最低限のフィールドで仮Nodeを生成）
+    LaunchedEffect(parentNodeId) {
+        val stubParentNode = Node(
+            id = parentNodeId,
+            type = parentNodeType,
+            title = parentNodeTitle,
+            content = "",
+            authorId = "",
+            authorName = "",
+            createdAt = "",
+        )
+        viewModel.setParentNode(stubParentNode)
+    }
+
+    LaunchedEffect(isSuccess) {
+        if (isSuccess) {
+            viewModel.reset()
+            onDismiss()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("派生投稿") },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        viewModel.reset()
+                        onDismiss()
+                    }) {
+                        Icon(Icons.Default.Close, contentDescription = "キャンセル")
+                    }
+                },
+                actions = {
+                    TextButton(
+                        onClick = { viewModel.submitDerived() },
+                        enabled = isValid && !isSubmitting,
+                    ) {
+                        Text(
+                            text = "投稿",
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+            ) {
+                // 派生元セクション
+                Text(
+                    text = "派生元",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                ParentNodeCard(
+                    nodeTitle = parentNodeTitle,
+                    nodeType = parentNodeType,
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // タイトル入力
+                Text(
+                    text = "タイトル",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { viewModel.updateTitle(it) },
+                    placeholder = { Text("派生アイデアのタイトルを入力...") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // 本文入力
+                Text(
+                    text = "本文",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = content,
+                    onValueChange = { viewModel.updateContent(it) },
+                    placeholder = { Text("派生アイデアの詳細を入力...") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 150.dp),
+                    singleLine = false,
+                    maxLines = 10,
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // タグ入力
+                TagInputComponent(
+                    tags = tags,
+                    tagSuggestions = tagSuggestions,
+                    onAddTag = { viewModel.addTag(it) },
+                    onRemoveTag = { viewModel.removeTag(it) },
+                    onSearchSuggestions = { viewModel.searchTagSuggestions(it) },
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // 送信中オーバーレイ
+            if (isSubmitting) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 派生元ノードを表示するカード
+ *
+ * 読み取り専用で派生元のノード種別アイコンとタイトルを表示する。
+ */
+@Composable
+private fun ParentNodeCard(
+    /** 派生元ノードのタイトル */
+    nodeTitle: String,
+    /** 派生元ノードの種別 */
+    nodeType: NodeType,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Bolt,
+            contentDescription = null,
+            tint = if (nodeType == NodeType.ISSUE) {
+                MaterialTheme.colorScheme.error
+            } else {
+                MaterialTheme.colorScheme.primary
+            },
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = if (nodeType == NodeType.ISSUE) "課題" else "アイデア",
+                style = MaterialTheme.typography.labelSmall,
+                color = if (nodeType == NodeType.ISSUE) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.primary
+                },
+            )
+            Text(
+                text = nodeTitle,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/screen/IdeaPostScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/screen/IdeaPostScreen.kt
@@ -1,0 +1,179 @@
+package io.github.witsisland.inspirehub.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.witsisland.inspirehub.presentation.viewmodel.PostViewModel
+import io.github.witsisland.inspirehub.ui.components.TagInputComponent
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * アイデア投稿画面
+ *
+ * タイトル・本文・タグを入力してアイデアを投稿するフォーム画面。
+ * タイトルと本文が入力されないと投稿ボタンが無効になる。
+ *
+ * - Note: 投稿完了後は onDismiss() を呼んで画面を閉じる
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IdeaPostScreen(
+    /** 画面を閉じるコールバック（完了・キャンセル共通） */
+    onDismiss: () -> Unit,
+    /** アイデア投稿ViewModel */
+    viewModel: PostViewModel = koinViewModel(),
+) {
+    val title by viewModel.title.collectAsState()
+    val content by viewModel.content.collectAsState()
+    val tags by viewModel.tags.collectAsState()
+    val tagSuggestions by viewModel.suggestedTags.collectAsState()
+    val isSubmitting by viewModel.isSubmitting.collectAsState()
+    val isValid by viewModel.isValid.collectAsState()
+    val isSuccess by viewModel.isSuccess.collectAsState()
+
+    LaunchedEffect(isSuccess) {
+        if (isSuccess) {
+            viewModel.reset()
+            onDismiss()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("アイデアを投稿") },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        viewModel.reset()
+                        onDismiss()
+                    }) {
+                        Icon(Icons.Default.Close, contentDescription = "キャンセル")
+                    }
+                },
+                actions = {
+                    TextButton(
+                        onClick = { viewModel.submitIdea() },
+                        enabled = isValid && !isSubmitting,
+                    ) {
+                        Text(
+                            text = "投稿",
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+            ) {
+                // タイトル入力
+                Text(
+                    text = "タイトル",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { viewModel.updateTitle(it) },
+                    placeholder = { Text("アイデアのタイトルを入力...") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // 本文入力
+                Text(
+                    text = "本文",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = content,
+                    onValueChange = { viewModel.updateContent(it) },
+                    placeholder = { Text("アイデアの詳細を入力...") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 150.dp),
+                    singleLine = false,
+                    maxLines = 10,
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // タグ入力
+                TagInputComponent(
+                    tags = tags,
+                    tagSuggestions = tagSuggestions,
+                    onAddTag = { viewModel.addTag(it) },
+                    onRemoveTag = { viewModel.removeTag(it) },
+                    onSearchSuggestions = { viewModel.searchTagSuggestions(it) },
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // テンプレ例文セクション
+                Text(
+                    text = "テンプレート例文",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "例: 「社内SNSに新着アイデアのダイジェスト通知機能を追加することで、見逃しを防ぎエンゲージメントを高められるのではないか。」",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // 送信中オーバーレイ
+            if (isSubmitting) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/screen/IssuePostScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/screen/IssuePostScreen.kt
@@ -1,0 +1,179 @@
+package io.github.witsisland.inspirehub.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.witsisland.inspirehub.presentation.viewmodel.PostViewModel
+import io.github.witsisland.inspirehub.ui.components.TagInputComponent
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * 課題投稿画面
+ *
+ * タイトル・本文・タグを入力して課題を投稿するフォーム画面。
+ * タイトルと本文が入力されないと投稿ボタンが無効になる。
+ *
+ * - Note: 投稿完了後は onDismiss() を呼んで画面を閉じる
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IssuePostScreen(
+    /** 画面を閉じるコールバック（完了・キャンセル共通） */
+    onDismiss: () -> Unit,
+    /** 課題投稿ViewModel */
+    viewModel: PostViewModel = koinViewModel(),
+) {
+    val title by viewModel.title.collectAsState()
+    val content by viewModel.content.collectAsState()
+    val tags by viewModel.tags.collectAsState()
+    val tagSuggestions by viewModel.suggestedTags.collectAsState()
+    val isSubmitting by viewModel.isSubmitting.collectAsState()
+    val isValid by viewModel.isValid.collectAsState()
+    val isSuccess by viewModel.isSuccess.collectAsState()
+
+    LaunchedEffect(isSuccess) {
+        if (isSuccess) {
+            viewModel.reset()
+            onDismiss()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("課題を投稿") },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        viewModel.reset()
+                        onDismiss()
+                    }) {
+                        Icon(Icons.Default.Close, contentDescription = "キャンセル")
+                    }
+                },
+                actions = {
+                    TextButton(
+                        onClick = { viewModel.submitIssue() },
+                        enabled = isValid && !isSubmitting,
+                    ) {
+                        Text(
+                            text = "投稿",
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+            ) {
+                // タイトル入力
+                Text(
+                    text = "タイトル",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { viewModel.updateTitle(it) },
+                    placeholder = { Text("課題のタイトルを入力...") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // 本文入力
+                Text(
+                    text = "本文",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = content,
+                    onValueChange = { viewModel.updateContent(it) },
+                    placeholder = { Text("課題の詳細を入力...") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 150.dp),
+                    singleLine = false,
+                    maxLines = 10,
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // タグ入力
+                TagInputComponent(
+                    tags = tags,
+                    tagSuggestions = tagSuggestions,
+                    onAddTag = { viewModel.addTag(it) },
+                    onRemoveTag = { viewModel.removeTag(it) },
+                    onSearchSuggestions = { viewModel.searchTagSuggestions(it) },
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // テンプレ例文セクション
+                Text(
+                    text = "テンプレート例文",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "例: 「リモートワークでの非同期コミュニケーションが難しく、情報の抜け漏れが発生している。特にタイムゾーンをまたぐメンバーとの連携で課題を感じている。」",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // 送信中オーバーレイ
+            if (isSubmitting) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/screen/PostTypeSelectSheet.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/witsisland/inspirehub/ui/screen/PostTypeSelectSheet.kt
@@ -1,0 +1,147 @@
+package io.github.witsisland.inspirehub.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * 投稿種別選択ボトムシート
+ *
+ * FABタップ後に表示され、「課題を投稿」か「アイデアを投稿」かを選択させる。
+ * 選択後はシートを閉じてコールバックを実行する。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostTypeSelectSheet(
+    /** シート非表示コールバック */
+    onDismiss: () -> Unit,
+    /** 課題投稿選択時コールバック */
+    onIssueSelected: () -> Unit,
+    /** アイデア投稿選択時コールバック */
+    onIdeaSelected: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 24.dp, end = 24.dp, bottom = 40.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "新規投稿",
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+
+            PostTypeItem(
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.Edit,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(28.dp),
+                    )
+                },
+                title = "課題を投稿",
+                subtitle = "課題や困りごとを共有する",
+                onClick = {
+                    onIssueSelected()
+                },
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            PostTypeItem(
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.Lightbulb,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(28.dp),
+                    )
+                },
+                title = "アイデアを投稿",
+                subtitle = "解決策やアイデアを投稿する",
+                onClick = {
+                    onIdeaSelected()
+                },
+            )
+        }
+    }
+}
+
+/**
+ * 投稿種別選択ボタン
+ *
+ * アイコン・タイトル・サブテキスト・chevronを横並びに表示するカードボタン。
+ */
+@Composable
+private fun PostTypeItem(
+    /** 左側アイコン */
+    icon: @Composable () -> Unit,
+    /** ボタンタイトル */
+    title: String,
+    /** サブテキスト */
+    subtitle: String,
+    /** タップコールバック */
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 0.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            icon()
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 概要

Android Phase 1 投稿フロー実装。FABタップから投稿完了までの一連のフローを実装する。

## 変更内容

- `PostTypeSelectSheet.kt`（投稿種別選択ボトムシート）
  - Material3 `ModalBottomSheet`
  - 課題/アイデア2択ボタン（アイコン・タイトル・サブテキスト・chevron）
- `TagInputComponent.kt`（タグ入力・サジェスト・FlowRow表示）
  - `OutlinedTextField` + 追加ボタン
  - `LazyRow` によるAPIサジェスト候補表示
  - `FlowRow`（`@ExperimentalLayoutApi`）による追加済みタグ表示（最大5個）
- `IssuePostScreen.kt`（課題投稿フォーム）
  - タイトル/本文/タグ/テンプレ例文セクション
  - `PostViewModel.submitIssue()` を使用
- `IdeaPostScreen.kt`（アイデア投稿フォーム）
  - IssuePostScreenと同構成
  - `PostViewModel.submitIdea()` を使用
- `DerivedPostScreen.kt`（派生投稿フォーム）
  - 派生元ノードカード（読み取り専用）
  - `PostViewModel.submitDerived()` を使用
- `MainScreen.kt` 修正
  - `showPostTypeSheet` → `PostTypeSelectSheet` 表示
  - `showIssuePost` / `showIdeaPost` State追加
  - フルスクリーン `Dialog` で投稿画面を表示

## ベースブランチ

`feat/android-main-navigation`（PR#135）に依存

## iOS参照

- `PostTypeSelectSheet.swift`, `IssuePostView.swift`, `IdeaPostView.swift`, `DerivedPostView.swift` を参考に実装

## ビルド確認

- [x] `./gradlew :shared:testDebugUnitTest` - SUCCESS
- [x] `./gradlew :composeApp:assembleDebug` - SUCCESS（新規ファイルのwarning 0件）

## 既知の既存warning（今回の変更とは無関係）

`DetailScreen.kt` の `Divider` 非推奨warning 2件（`HorizontalDivider` に変更推奨）

🤖 Generated with Claude Code