### PR TITLE
fix: JAVA_HOMEを条件付き設定にしてXcode Cloudビルドを修復

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -185,7 +185,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/zsh;
-			shellScript = "# JAVA_HOMEの認識エラーで/bin/zshで実行\n# 参考：https://qiita.com/nacho4d/items/6d04c9287c55c26fca95\n\n# Android Studio組み込みJDKをJAVA_HOMEに設定\nexport JAVA_HOME=\"/Applications/Android Studio.app/Contents/jbr/Contents/Home\"\n\nif [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\n\ncd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
+			shellScript = "# JAVA_HOMEの認識エラーで/bin/zshで実行\n# 参考：https://qiita.com/nacho4d/items/6d04c9287c55c26fca95\n\n# Android Studio同梱JDKがあればJAVA_HOMEに設定（ローカル開発用）\nAS_JDK=\"/Applications/Android Studio.app/Contents/jbr/Contents/Home\"\nif [ -d \"$AS_JDK\" ]; then\n  export JAVA_HOME=\"$AS_JDK\"\nfi\n\nif [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\n\ncd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Summary

- PR #133でJAVA_HOMEをAndroid Studioのパスにハードコードしたため、Xcode Cloudでビルドが失敗していた
- Android Studioが存在する場合のみJAVA_HOMEを設定する条件分岐に変更
- Xcode Cloudでは`ci_post_clone.sh`で設定されたJAVA_HOME（Homebrew openjdk@17）がそのまま使われる

## 変更箇所

`iosApp/iosApp.xcodeproj/project.pbxproj` のCompile Kotlin Frameworkビルドフェーズスクリプト:

```bash
# Before（ハードコード → Xcode Cloudで失敗）
export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"

# After（条件分岐 → 全環境対応）
AS_JDK="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
if [ -d "$AS_JDK" ]; then
  export JAVA_HOME="$AS_JDK"
fi
```

## Test plan

- [ ] ローカルXcodeビルドが通ることを確認
- [ ] Xcode Cloudビルドが通ることを確認

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)